### PR TITLE
Change how spirv-cross.a is archived for Linux to fix an error when linking with it

### DIFF
--- a/.yamato/linux-build.yml
+++ b/.yamato/linux-build.yml
@@ -16,7 +16,9 @@ commands:
         - |
             cd _builds
             ls
-            ar rcs spirv-cross.a libspirv-cross-c.a libspirv-cross-core.a libspirv-cross-cpp.a libspirv-cross-glsl.a libspirv-cross-hlsl.a libspirv-cross-msl.a libspirv-cross-reflect.a libspirv-cross-util.a
+            for i in *.a; do ar -x "$i"; done
+            ls
+            ar -cq spirv-cross.a *.o
             cd ../
             mkdir spirv-cross
             cp "_builds/spirv-cross.a" spirv-cross


### PR DESCRIPTION
This PR fixes: `Archive has no index; combine multiple archive files into one` error when linking with the generated `spirv-cross.a`

Instead of the current use of `ar` to combine existing SPIRV-Cross `.a` files into one `spirv-cross.a` file, here we first split the existing .a files into their constituent .o files before combining them into the final archive.