### PR TITLE
Add apple silicon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /external
 .vs/
 *.vcxproj.user
+/build
 /_builds
 
 !CMakeLists.txt

--- a/.yamato/all.yaml
+++ b/.yamato/all.yaml
@@ -1,0 +1,5 @@
+name: Build SPIRV-Cross - all targets
+dependencies:
+    - .yamato/linux-build.yml
+    - .yamato/macos-build.yml
+    - .yamato/windows-build.yml

--- a/.yamato/all.yaml
+++ b/.yamato/all.yaml
@@ -1,5 +1,5 @@
 name: Build SPIRV-Cross - all targets
 dependencies:
     - .yamato/linux-build.yml
-    - .yamato/macos-build.yml
+    - .yamato/osx-build.yml
     - .yamato/windows-build.yml

--- a/.yamato/linux-build.yml
+++ b/.yamato/linux-build.yml
@@ -3,7 +3,7 @@ agent:
     type: Unity::VM
     image: cds-ops/ubuntu-18.04-katana-agent
     flavor: b1.small
-    
+
 commands:
         - sudo apt-get install ninja-build
         - |
@@ -20,8 +20,8 @@ commands:
             ls
             ar -cq spirv-cross.a *.o
             cd ../
-            mkdir spirv-cross
-            cp "_builds/spirv-cross.a" spirv-cross
+            mkdir -p spirv-cross/linux
+            cp "_builds/spirv-cross.a" spirv-cross/linux
 artifacts:
     builds:
       paths:

--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -5,6 +5,7 @@ agent:
     flavor: b1.medium
 
 commands:
+        - brew install cmake
         - |
             cd ../
             export APPLE_X64_FLAGS="-target x86_64-apple-macos10.12"

--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -1,25 +1,35 @@
-name: "Mac - Build SPIRV-Cross"
+name: "Mac - Build SPIRV-Cross x64 + arm64"
 agent:
     type: Unity::VM::osx
-    image: mobile/macos-10.15-testing:latest
-    flavor: b1.small
+    image: platform-foundation/mac-bokken:latest
+    flavor: b1.medium
 
-commands: 
-        - brew install cmake
-        - brew install ninja
+commands:
         - |
-            export CC=`xcrun -find cc`
-            export CXX=`xcrun -find c++`
             cd ../
-            cmake -HSPIRV-Cross -BSPIRV-Cross/_builds -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF
-            cd SPIRV-Cross
-            cmake --build _builds --config Release
+            export APPLE_X64_FLAGS="-target x86_64-apple-macos10.12"
+            cmake -HSPIRV-Cross -BSPIRV-Cross/build/x64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_X64_FLAGS}"
+            cd SPIRV-Cross/build/x64
+            cmake --build . --config Release
         - |
-            cd _builds
+            cd build/x64
             libtool -static -o spirv-cross.a libspirv-cross-c.a libspirv-cross-core.a libspirv-cross-cpp.a libspirv-cross-glsl.a libspirv-cross-hlsl.a libspirv-cross-msl.a libspirv-cross-reflect.a libspirv-cross-util.a
+            cd ../../
+            mkdir -p spirv-cross/macos/x64
+            cp build/x64/spirv-cross.a spirv-cross/macos/x64
+        - |
             cd ../
-            mkdir spirv-cross
-            cp "_builds/spirv-cross.a" spirv-cross
+            export APPLE_ARM64_FLAGS="-target arm64-apple-macos11"
+            cmake -HSPIRV-Cross -BSPIRV-Cross/build/arm64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_ARM64_FLAGS}"
+            cd SPIRV-Cross/build/arm64
+            cmake --build . --config Release
+        - |
+            cd build/arm64
+            libtool -static -o spirv-cross.a libspirv-cross-c.a libspirv-cross-core.a libspirv-cross-cpp.a libspirv-cross-glsl.a libspirv-cross-hlsl.a libspirv-cross-msl.a libspirv-cross-reflect.a libspirv-cross-util.a
+            cd ../../
+            mkdir -p spirv-cross/macos/arm64
+            cp build/arm64/spirv-cross.a spirv-cross/macos/arm64
+
 artifacts:
     builds:
       paths:

--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -1,14 +1,14 @@
 name: "Mac - Build SPIRV-Cross x64 + arm64"
 agent:
     type: Unity::VM::osx
-    image: platform-foundation/mac-bokken:latest
+    image: desktop/unity-macos-10.15-xcode-12.2:stable
     flavor: b1.medium
 
 commands:
         - |
             cd ../
             export APPLE_X64_FLAGS="-target x86_64-apple-macos10.12"
-            export OSX_SYSROOT="/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
+            export OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
             cmake -HSPIRV-Cross -BSPIRV-Cross/build/x64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_OSX_SYSROOT="${OSX_SYSROOT}"
             cd SPIRV-Cross/build/x64
             cmake --build . --config Release
@@ -21,7 +21,7 @@ commands:
         - |
             cd ../
             export APPLE_ARM64_FLAGS="-target arm64-apple-macos11"
-            export OSX_SYSROOT="/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
+            export OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
             cmake -HSPIRV-Cross -BSPIRV-Cross/build/arm64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_OSX_SYSROOT="${OSX_SYSROOT}"
             cd SPIRV-Cross/build/arm64
             cmake --build . --config Release

--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -29,6 +29,9 @@ commands:
             cd ../../
             mkdir -p spirv-cross/macos/arm64
             cp build/arm64/spirv-cross.a spirv-cross/macos/arm64
+        - |
+            echo "Obtained from https://github.com/Unity-Technologies/SPIRV-Cross" > spirv-cross/version.txt
+            git rev-parse HEAD >> spirv-cross/version.txt
 
 artifacts:
     builds:

--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -8,7 +8,8 @@ commands:
         - |
             cd ../
             export APPLE_X64_FLAGS="-target x86_64-apple-macos10.12"
-            cmake -HSPIRV-Cross -BSPIRV-Cross/build/x64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_X64_FLAGS}"
+            export OSX_SYSROOT="/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
+            cmake -HSPIRV-Cross -BSPIRV-Cross/build/x64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_OSX_SYSROOT="${OSX_SYSROOT}"
             cd SPIRV-Cross/build/x64
             cmake --build . --config Release
         - |
@@ -20,7 +21,8 @@ commands:
         - |
             cd ../
             export APPLE_ARM64_FLAGS="-target arm64-apple-macos11"
-            cmake -HSPIRV-Cross -BSPIRV-Cross/build/arm64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_ARM64_FLAGS}"
+            export OSX_SYSROOT="/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
+            cmake -HSPIRV-Cross -BSPIRV-Cross/build/arm64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_OSX_SYSROOT="${OSX_SYSROOT}"
             cd SPIRV-Cross/build/arm64
             cmake --build . --config Release
         - |

--- a/.yamato/windows-build.yml
+++ b/.yamato/windows-build.yml
@@ -3,23 +3,23 @@ agent:
     type: Unity::VM
     image: sdet/scripting-toolbox-vs2015
     flavor: b1.small
-    
-interpreter: powershell    
+
+interpreter: powershell
 commands:
         - |
             choco install python --version=3.7.2
             choco install cmake --version=3.11.2
             Start-Process -FilePath "C:\ProgramData\Package Cache\{68432bbb-c9a5-4a7b-bab3-ae5a49b28303}\vs_professional.exe" -Wait -ArgumentList "/InstallSelectableItems ToolsForWin81_WP80_WP81V1 /passive"
         - |
-            $env:Path += ";C:\Program Files\CMake\bin\;C:\Python37\Scripts\;C:\Python37\" 
-            cd ../
+            $env:Path += ";C:\Program Files\CMake\bin\;C:\Python37\Scripts\;C:\Python37\"
+            cd ..
             cmake "-GVisual Studio 14 2015 Win64" -HSPIRV-Cross -BSPIRV-Cross/_builds -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=ON
             cd SPIRV-Cross
             cmake --build _builds --config Release
         - |
-            mkdir spirv-cross
-            Copy-Item "_builds/Release/spirv-cross-c-shared.dll" spirv-cross
-            Copy-Item "_builds/Release/spirv-cross-c-shared.lib" spirv-cross
+            md -force .\spirv-cross\win
+            Copy-Item "_builds/Release/spirv-cross-c-shared.dll" .\spirv-cross\win
+            Copy-Item "_builds/Release/spirv-cross-c-shared.lib" .\spirv-cross\win
 artifacts:
     builds:
       paths:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ endif()
 
 project(SPIRV-Cross LANGUAGES CXX C)
 enable_testing()
- 
-if(APPLE)
+
+if(APPLE AND NOT "${CMAKE_CXX_FLAGS}" MATCHES "-target|-mmacosx-version-min=")
 	message(STATUS "Adding C++ compiler flag: -mmacosx-version-min=10.12")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.12")
 endif()


### PR DESCRIPTION
Added support for arm64 builds on macOS. This required upgrades of the macOS configuration, as well as some minor tweaks.

Added ability to build multiple macOS targets in one builder
Reduced size of builders to save resources
Made pathing consistent across all builders so that we can combine into one zip file like the other repositories.
Added version.txt so we can trace back.
Fixed cmake builder to recognize -mmacOS-version-min or target if experimenting on the command line

This is step one of support; step two is adding builds.zip to trunk.