### PR TITLE
Switch to image with working 'brew' to fix rotted OSX build

### DIFF
--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -1,7 +1,7 @@
 name: "Mac - Build SPIRV-Cross x64 + arm64"
 agent:
     type: Unity::VM::osx
-    image: desktop/unity-macos-10.15-xcode-12.2:stable
+    image: slough-ops/macos-10.15-base:v0.1.8-749587
     flavor: b1.medium
 
 commands:

--- a/.yamato/osx-build.yml
+++ b/.yamato/osx-build.yml
@@ -9,8 +9,7 @@ commands:
         - |
             cd ../
             export APPLE_X64_FLAGS="-target x86_64-apple-macos10.12"
-            export OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
-            cmake -HSPIRV-Cross -BSPIRV-Cross/build/x64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_OSX_SYSROOT="${OSX_SYSROOT}"
+            cmake -HSPIRV-Cross -BSPIRV-Cross/build/x64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_X64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_X64_FLAGS}"
             cd SPIRV-Cross/build/x64
             cmake --build . --config Release
         - |
@@ -22,8 +21,7 @@ commands:
         - |
             cd ../
             export APPLE_ARM64_FLAGS="-target arm64-apple-macos11"
-            export OSX_SYSROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.0.sdk"
-            cmake -HSPIRV-Cross -BSPIRV-Cross/build/arm64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_OSX_SYSROOT="${OSX_SYSROOT}"
+            cmake -HSPIRV-Cross -BSPIRV-Cross/build/arm64 -DSPIRV_CROSS_STATIC=ON -DSPIRV_CROSS_SHARED=OFF -DCMAKE_CXX_FLAGS="${APPLE_ARM64_FLAGS}" -DCMAKE_C_FLAGS="${APPLE_ARM64_FLAGS}"
             cd SPIRV-Cross/build/arm64
             cmake --build . --config Release
         - |


### PR DESCRIPTION
Brew stopped working in the previously used base image, this broke the OSX build as `CMake` and `Ninja` could no longer be downloaded.

**PR changes:**
* Switched to a simpler image with explicit version `slough-ops/macos-10.15-base:v0.1.8-749587` for several reasons:
   1. To fix the rotten OSX build ('brew' now works)
   2. To simplify the image dependency chain for future maintenance (hard to get latest fixes in derived images)
   3. Switched to explicit version to avoid unexpectedly getting breaking changes
* Removed use of custom Xcode sysroot as new image no longer even has an `/Applications/Xcode.app` folder
* Generated binaries now show an sdk version `11.1` instead of `11.0`

**N.B.** The OSX build now produces warnings for the x86_64 and arm64 builds respectively:
`clang: warning: overriding '-mmacosx-version-min=10.15' option with '-target x86_64-apple-macos10.12' [-Woverriding-t-option]`
`clang: warning: overriding '-mmacosx-version-min=10.15' option with '-target arm64-apple-macos11' [-Woverriding-t-option]`
however, inspecting the generated `.a` files with `otool -l` shows that they have the same minos versions as the pre-issue build (the x86_64 has `LC_VERSION_MIN_MACOSX` of `10.12` the arm64 library has `minos: 11.0`  ) so this might not be an issue.